### PR TITLE
Update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ The download transaction data run
 ```
 scrapy crawl transactions -L INFO
 ```
+# Considerations for Unix systems
+To run the eutl scraper on macOS or Linux, delete the entry for the package "twisted-iocpsupport".
+The package twisted-iocpsupport provides bindings to the Windows "I/O Completion Ports" APIs. These are Windows-only APIs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,5 @@ Twisted==21.7.0
 twisted-iocpsupport==1.0.2
 typing-extensions==3.10.0.2
 w3lib==1.22.0
+wheel==0.37.1
 zope.interface==5.4.0


### PR DESCRIPTION
The installation of dependencies from the requirements.txt drops ```error: invalid command 'bdist_wheel'``` twice, and occurs on Ubuntu and macOS. It is caused by the building of the packages Protego and PyDispatcher. Hence I added the "wheel"-package to avoid this error. 

Added considerations for the installation on Unix systems to the README.
Tested the setup on Ubuntu (20.04) and macOS (Catalina).