### PR TITLE
Update Orbis identifier imputation

### DIFF
--- a/main_data_imputation.py
+++ b/main_data_imputation.py
@@ -39,8 +39,9 @@ def ingest_data(dir_parsed, dir_additional):
     # impute orbis matching from JRC
     fn_jrc = dir_additional + "jrc_orbis_ids/JRC-EU ETS-FIRMS_V2_012022_public.xlsx"
     fn_acc = dir_parsed + "accounts.csv"
+    fn_contacts = dir_parsed + "contacts.csv"
     fn_out = dir_parsed + "accounts_w_orbis.csv"
-    impute_orbis_identifiers(fn_jrc, fn_acc, fn_out)
+    impute_orbis_identifiers(fn_jrc, fn_acc, fn_contacts, fn_out)
 
     return {
         "accounts_w_orbis": fn_out,

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ Scrapy==2.5.1
 service-identity==21.1.0
 six==1.16.0
 Twisted==21.7.0
-twisted-iocpsupport==1.0.2
+# twisted-iocpsupport==1.0.2
 typing-extensions==3.10.0.2
 w3lib==1.22.0
 wheel==0.37.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ Scrapy==2.5.1
 service-identity==21.1.0
 six==1.16.0
 Twisted==21.7.0
-# twisted-iocpsupport==1.0.2
+twisted-iocpsupport==1.0.2
 typing-extensions==3.10.0.2
 w3lib==1.22.0
 wheel==0.37.1


### PR DESCRIPTION
This pull request improves the imputation of Orbis identifiers in two ways.

### Incorrectly formatted national identifiers

- Some national identifiers in the JRC data appear to miss leading `0`s. For example, Umicore's `EUTL_REGID` (JRC) is stored as `401574852` whereas its `companyRegistrationNumber` (EUTL) is `0401574852`. (This is potentially due to Excel automatically formatting numeric strings as numbers and therefore removing leading `0`s.)
- This pull request updates `get_orbis_identifiers` to include a second merge on a stripped version of the national identifiers where leading zeroes are removed.
- In the 2023 of the EUTL, this results in 240 additional matches between JRC and EUTL.

### Merge on national identifiers

- The imputation of Orbis identifiers in the module `get_orbis_identifiers` performs a merge on `companyRegistrationNumber` alone. However, because national identifier are unique only within a single country, some account holders are matched to a `companyRegistrationNumber` in a different country.
- This pull request includes the `countryCode` of an account holder and performs the merge on the combination of `countryCode` and `companyRegistrationNumber`.
- In the 2023 version of the EUTL, only two mismatches seem to have occurred (`HSWT FRANCE` was matched to `Hrvatska industrija šećera d.d.` and `Myska, Martin` was matched to `BlueSky Carbon Limited`)