### PR TITLE
Preserve NACE codes

### DIFF
--- a/main_data_imputation.py
+++ b/main_data_imputation.py
@@ -34,7 +34,7 @@ def ingest_data(dir_parsed, dir_additional):
     fn_leakage_2015 = dir_additional + "leakage_list/leakage_2015.xls"
     fn_leakage_2020 = dir_additional + "leakage_list/leakage_2020.xlsx"
     fn_nace_installations = dir_additional + "nace_leakage.csv"
-    parse_leakage_lists(fn_leakage_2015, fn_leakage_2020, fn_out=fn_nace_installations)
+    parse_leakage_lists(fn_leakage_2015, fn_leakage_2020, fn_out=fn_nace_installations, fn_nace=fn_nace_scheme)
 
     # impute orbis matching from JRC
     fn_jrc = dir_additional + "jrc_orbis_ids/JRC-EU ETS-FIRMS_V2_012022_public.xlsx"


### PR DESCRIPTION
This pull request ensures proper formatting of the NACE codes in the carbon leakage lists.

The main changes are in `get_nace_classifications`:

- read the NACE codes in the carbon leakage list as string: currently the NACE codes are read as `float` and therefore 4-digit codes ending with `0` are implicitly cast to the 3-digit level (e.g., `06.10` is read as `06.1`)
- the carbon leakage list itself is inconsistently formatted, e.g., some installations have NACE code `35.00` which is not a valid 4-digit code; codes that are invalid at the 4-digit level are cast to the nearest valid NACE code (e.g., `35.00` is converted to `35`)

The updates increase the number of installations with a 4-digit NACE code from 9,170 to 14,366 (because the implicitly downcast from 4-digit to 3-digit level is avoided). Remaining are 407 installations with a 3-digit NACE code and 311 with a 2-digit NACE code.

There are also minor tweaks to `create_tables`:

- use the processed `nace` from the file instead of repeating the processing
- update the merge key for installations in Northern Ireland